### PR TITLE
Remove no longer needed Paperclip setting :only_process

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -23,7 +23,6 @@ class Asset
     max_size:        50.megabytes,
     url:             '/system/:attachment/:mon_year/:id/:style/:filename',
     path:            ':rails_root/public:url',
-    only_process:    [:admin],
     styles:          Slices::Config.asset_styles,
     convert_options: Slices::Config.asset_convert_options
 


### PR DESCRIPTION
This caused this issue: https://sohohouse.sifterapp.com/issues/1382
The issue was that assets that replaced a previous asset were no longer
uploaded since the Paperclip processing was set to not reprocess original.

As far as I can tell from the source code I don't think this :only_process
is needed for anything really. Safest seems to be to remove it altogether.

The change in Paperclip was https://github.com/thoughtbot/paperclip/pull/1993/commits/bb4e2245438a9fdaaa7bad0e46f5a2021e599c93