### PR TITLE
Accept the correct id attribute when writing embedded fields

### DIFF
--- a/app/models/slice.rb
+++ b/app/models/slice.rb
@@ -89,8 +89,9 @@ class Slice
       next unless attrs.has_key?(field)
 
       attrs[field] = (attrs[field] || []).map do |embedded_attrs|
-        if embedded_attrs['id'].present?
-          embedded_doc = send(field).find(embedded_attrs['id'])
+        id = embedded_attrs['id'] || embedded_attrs['_id']
+        if id.present?
+          embedded_doc = send(field).find(id)
           embedded_doc.write_attributes(embedded_attrs)
           embedded_doc
         else

--- a/spec/models/slice/write_attributes_spec.rb
+++ b/spec/models/slice/write_attributes_spec.rb
@@ -6,7 +6,7 @@ describe Slice, type: :model do
       class Embeddable
         include Mongoid::Document
         embedded_in :test_slice
-        field :data
+        field :data, localize: true
       end
 
       class TestSlice < Slice
@@ -31,17 +31,21 @@ describe Slice, type: :model do
       end
 
       context "when the embeddable already exists" do
-        let(:embeddable) { Embeddable.new(data: "old") }
-        before { slice.embeddables = [embeddable] }
+        let(:embeddable) { Embeddable.new(data_translations: { 'en' => "old", 'de' => 'german old' }) }
+        before do
+          slice.embeddables = [embeddable]
+        end
+
         let :embedded_attrs do
           {
-            _id: embeddable.id,
-            data: "new",
+            '_id' => embeddable.id,
+            'data' => "new",
           }
         end
 
         it "updates the embeddable" do
           expect(subject.data).to eq("new")
+          I18n.with_locale(:de) { expect(subject.data).to eq('german old') }
         end
 
         context "when embeddable field is not present in attributes" do


### PR DESCRIPTION
When updating slices which have nested classes, the nested fields come in with an _id attribute, whereas the method to update nested models checks for an id attribute. This meant that it was instantiating a new instance of the embedded class rather than updating the existing one.

See https://github.com/SohoHouse/house_seven/pull/1077