### PR TITLE
Check for pdf file extension in NameSanitizer

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -187,7 +187,7 @@ class Asset
   class FilenameSanitizer
     QUITE_LONG_FILENAME_LENGTH = 100
     INVALID_FILENAME_CHARACTERS = /[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/
-    EXTENSION_REGEX = /\.#{IMAGE_REGEX}$/
+    EXTENSION_REGEX = /\.(#{IMAGE_REGEX}|pdf)$/
 
     attr_reader :file, :name
 

--- a/spec/models/asset/rename_spec.rb
+++ b/spec/models/asset/rename_spec.rb
@@ -11,12 +11,24 @@ describe "Renaming an asset", type: :model do
       asset.save!
     end
 
-    it "ensures the extension is maintained" do
-      expect(asset.name).to eq("Cute_Ladybird.jpg")
-    end
+    context "correctly saves the filename and extension" do
+      context "for jpg" do
+        it "ensures the extension is maintained" do
+          expect(asset.name).to eq("Cute_Ladybird.jpg")
+        end
 
-    it "alters the file name accordingly" do
-      expect(asset.file_file_name).to eq("Cute_Ladybird.jpg")
+        it "alters the file name accordingly" do
+          expect(asset.file_file_name).to eq("Cute_Ladybird.jpg")
+        end
+      end
+
+      context "for pdf" do
+        it "ensures the extension is maintained" do
+          pdf = Asset.make file: file_fixture('test.pdf')
+          expect(pdf.name).to eq("test.pdf")
+        end
+      end
+
     end
 
     it "moves the file on storage" do


### PR DESCRIPTION
Currently only image extensions are checked and sanitised correctly when an asset is uploaded. If a pdf file is uploaded, the NameSanitizer does not take into account the extension of the file and appends '.pdf' to the file, resulting in '.pdf' displayed twice. 